### PR TITLE
Version 1.1.3

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="rainforest-cordova-plugin" version="1.1.2">
+        id="rainforest-cordova-plugin" version="1.1.3">
     <name>Rainforest QA</name>
     <description>Rainforest QA Cordova Plugin</description>
     <license>MIT</license>

--- a/src/hooks/addEmbedded.js
+++ b/src/hooks/addEmbedded.js
@@ -91,7 +91,7 @@ module.exports = function(context) {
 
     const projectName = myProj.getFirstTarget().firstTarget.name.replace(/^["]+|["]+$/g, '');
     const groupName = 'Embed Frameworks ' + context.opts.plugin.id;
-    const pluginPathInPlatformIosDir = projectName + '/plugins/' + context.opts.plugin.id;
+    const pluginPathInPlatformIosDir = projectName + '/Plugins/' + context.opts.plugin.id;
 
     process.chdir('./platforms/ios');
     const frameworkFilesToEmbed = fromDir(pluginPathInPlatformIosDir ,'.framework', false, true);


### PR DESCRIPTION
Fix framework reference path.

This problem was introduced by https://github.com/rainforestapp/rainforest-cordova-plugin/pull/6/files#diff-aaf7ebd7e433a39c0b5301050db44d94R94

The framework is installed in the `Plugins` folder inside of the generated ios project. For example:
`<ionic-project>/platforms/ios/<ionic-project>/Plugins`